### PR TITLE
Reverted declaration sites for TemplateType and StaticType, added constraint to TemplateType

### DIFF
--- a/src/AtClass.php
+++ b/src/AtClass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Typhoon\Type;
+
+/**
+ * @api
+ * @psalm-immutable
+ */
+final class AtClass
+{
+    /**
+     * @var class-string
+     */
+    public readonly string $name;
+
+    /**
+     * @internal
+     * @psalm-internal Typhoon\Type
+     * @param class-string $name
+     */
+    public function __construct(
+        string $name,
+    ) {
+        $this->name = $name;
+    }
+}

--- a/src/AtFunction.php
+++ b/src/AtFunction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Typhoon\Type;
+
+/**
+ * @api
+ * @psalm-immutable
+ */
+final class AtFunction
+{
+    /**
+     * @var callable-string
+     */
+    public readonly string $name;
+
+    /**
+     * @internal
+     * @psalm-internal Typhoon\Type
+     * @param callable-string $name
+     */
+    public function __construct(
+        string $name,
+    ) {
+        $this->name = $name;
+    }
+}

--- a/src/AtMethod.php
+++ b/src/AtMethod.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Typhoon\Type;
+
+/**
+ * @api
+ * @psalm-immutable
+ */
+final class AtMethod
+{
+    /**
+     * @var class-string
+     */
+    public readonly string $class;
+
+    /**
+     * @var non-empty-string
+     */
+    public readonly string $name;
+
+    /**
+     * @internal
+     * @psalm-internal Typhoon\Type
+     * @param class-string $class
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        string $class,
+        string $name,
+    ) {
+        $this->class = $class;
+        $this->name = $name;
+    }
+}

--- a/src/StaticType.php
+++ b/src/StaticType.php
@@ -13,6 +13,11 @@ namespace Typhoon\Type;
 final class StaticType implements Type
 {
     /**
+     * @var class-string<TObject>
+     */
+    public readonly string $declaredAtClass;
+
+    /**
      * @var list<Type>
      */
     public readonly array $templateArguments;
@@ -21,11 +26,14 @@ final class StaticType implements Type
      * @internal
      * @psalm-internal Typhoon\Type
      * @no-named-arguments
+     * @param class-string<TObject> $declaredAtClass
      * @param list<Type> $templateArguments
      */
     public function __construct(
+        string $declaredAtClass,
         array $templateArguments = [],
     ) {
+        $this->declaredAtClass = $declaredAtClass;
         $this->templateArguments = $templateArguments;
     }
 

--- a/src/TemplateType.php
+++ b/src/TemplateType.php
@@ -19,12 +19,16 @@ final class TemplateType implements Type
 
     public readonly AtMethod|AtClass|AtFunction $declaredAt;
 
+    /**
+     * @var Type<TType>
+     */
     public readonly Type $constraint;
 
     /**
      * @internal
      * @psalm-internal Typhoon\Type
      * @param non-empty-string $name
+     * @param Type<TType> $constraint
      */
     public function __construct(
         string $name,

--- a/src/TemplateType.php
+++ b/src/TemplateType.php
@@ -17,6 +17,10 @@ final class TemplateType implements Type
      */
     public readonly string $name;
 
+    public readonly AtMethod|AtClass|AtFunction $declaredAt;
+
+    public readonly Type $constraint;
+
     /**
      * @internal
      * @psalm-internal Typhoon\Type
@@ -24,8 +28,12 @@ final class TemplateType implements Type
      */
     public function __construct(
         string $name,
+        AtFunction|AtClass|AtMethod $declaredAt,
+        Type $constraint,
     ) {
         $this->name = $name;
+        $this->declaredAt = $declaredAt;
+        $this->constraint = $constraint;
     }
 
     public function accept(TypeVisitor $visitor): mixed

--- a/src/types.php
+++ b/src/types.php
@@ -370,7 +370,10 @@ final class types
 
     /**
      * @psalm-pure
+     * @template TType
      * @param non-empty-string $name
+     * @param Type<TType> $constraint
+     * @return TemplateType<TType>
      */
     public static function template(string $name, AtMethod|AtClass|AtFunction $declaredAt, Type $constraint = self::mixed): TemplateType
     {

--- a/src/types.php
+++ b/src/types.php
@@ -265,10 +265,13 @@ final class types
     /**
      * @psalm-pure
      * @no-named-arguments
+     * @template TObject of object
+     * @param class-string<TObject> $declaredAtClass
+     * @return StaticType<TObject>
      */
-    public static function static(Type ...$templateArguments): StaticType
+    public static function static(string $declaredAtClass, Type ...$templateArguments): StaticType
     {
-        return new StaticType($templateArguments);
+        return new StaticType($declaredAtClass, $templateArguments);
     }
 
     /**
@@ -369,9 +372,34 @@ final class types
      * @psalm-pure
      * @param non-empty-string $name
      */
-    public static function template(string $name): TemplateType
+    public static function template(string $name, AtMethod|AtClass|AtFunction $declaredAt, Type $constraint = self::mixed): TemplateType
     {
-        return new TemplateType($name);
+        return new TemplateType($name, $declaredAt, $constraint);
+    }
+
+    /**
+     * @param callable-string $name
+     */
+    public static function atFunction(string $name): AtFunction
+    {
+        return new AtFunction($name);
+    }
+
+    /**
+     * @param class-string $name
+     */
+    public static function atClass(string $name): AtClass
+    {
+        return new AtClass($name);
+    }
+
+    /**
+     * @param class-string $class
+     * @param non-empty-string $name
+     */
+    public static function atMethod(string $class, string $name): AtMethod
+    {
+        return new AtMethod($class, $name);
     }
 
     /**

--- a/tests/psalm/StaticType.phpt
+++ b/tests/psalm/StaticType.phpt
@@ -3,7 +3,7 @@
 
 namespace Typhoon\Type;
 
-$_type = PsalmTest::extractType(new StaticType());
-/** @psalm-check-type-exact $_type = \object */
+$_type = PsalmTest::extractType(new StaticType(\stdClass::class));
+/** @psalm-check-type-exact $_type = \stdClass */
 
 --EXPECT--

--- a/tests/psalm/TemplateType.phpt
+++ b/tests/psalm/TemplateType.phpt
@@ -3,7 +3,7 @@
 
 namespace Typhoon\Type;
 
-$_type = PsalmTest::extractType(new TemplateType('T'));
+$_type = PsalmTest::extractType(new TemplateType('T', new AtFunction('trim'), MixedType::type));
 /** @psalm-check-type-exact $_type = \mixed */
 
 --EXPECT--

--- a/tests/psalm/TemplateType.phpt
+++ b/tests/psalm/TemplateType.phpt
@@ -3,7 +3,7 @@
 
 namespace Typhoon\Type;
 
-$_type = PsalmTest::extractType(new TemplateType('T', new AtFunction('trim'), MixedType::type));
-/** @psalm-check-type-exact $_type = \mixed */
+$_type = PsalmTest::extractType(new TemplateType('T', new AtFunction('trim'), ObjectType::type));
+/** @psalm-check-type-exact $_type = \object */
 
 --EXPECT--


### PR DESCRIPTION
This is reverted due to discussion in https://www.youtube.com/live/DcObNIRECdc?si=SgeXDe80tCieUAmA&t=903.

Basically, keeping track of declaration site will allow (hopefully) to validate passed types without any additional context.